### PR TITLE
Fix network connection in debug mode

### DIFF
--- a/android/moviesreloaded/src/debug/AndroidManifest.xml
+++ b/android/moviesreloaded/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+</manifest>

--- a/android/moviesreloaded/src/main/AndroidManifest.xml
+++ b/android/moviesreloaded/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.walmartlabs.moviesreloaded">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
This fixes the network connection problems in debug mode for Android 8+ devices by setting `android:usesCleartextTraffic` to true.