### PR TITLE
send finalPayLoad as NSObject

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENMiniAppNavDataProvider.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENMiniAppNavDataProvider.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public typealias MiniAppFinishedCallback = (String?) -> Void
+public typealias MiniAppFinishedCallback = (AnyObject?) -> Void
 
 @objc public protocol ENMiniAppNavDataProvider: ENMiniAppDataProvider {
     var finishedCallback: MiniAppFinishedCallback? { get set }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -58,8 +58,9 @@ import UIKit
     }
 
     func handleFinishFlow(finalPayload: String?, completion: @escaping ERNNavigationCompletionBlock) {
+        let payloadJson = self.convertStringToJSONObject(jsonPayLoad: finalPayload)
         if ((self.viewController?.finishedCallback) != nil) {
-            self.viewController?.finishedCallback?(finalPayload)
+            self.viewController?.finishedCallback?(payloadJson)
         }
         return completion("Finished status")
     }
@@ -160,11 +161,13 @@ import UIKit
         }
     }
 
-    private func convertStringToDictionary(jsonPayLoad: String) -> [String: Any]? {
+    private func convertStringToJSONObject(jsonPayLoad: String?) -> AnyObject? {
         do {
-            if let data = jsonPayLoad.data(using: String.Encoding.utf8) {
-                let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-                return json
+            if let payload = jsonPayLoad, let data = payload.data(using: String.Encoding.utf8) {
+                let json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+                return json as AnyObject
+            } else {
+                return nil
             }
         } catch let error as NSError {
             NSLog(error.description)

--- a/ios/moviesreloadedMiniApp/ErnRunner/ViewController.m
+++ b/ios/moviesreloadedMiniApp/ErnRunner/ViewController.m
@@ -17,7 +17,7 @@
 #import "RunnerConfig.h"
 #import <ElectrodeContainer/ElectrodeContainer.h>
 
-typedef void(^MiniAppFinishedCallback)(NSString *_Nullable);
+typedef void (^MiniAppFinishedCallback)(id _Nullable);
 
 @implementation ViewController
 
@@ -51,8 +51,13 @@ typedef void(^MiniAppFinishedCallback)(NSString *_Nullable);
 }
 
 - (MiniAppFinishedCallback _Nullable)finishedCallback {
-    return ^(NSString *payload){
-        exit(0);
+    return ^(NSObject *payload){
+        if ([payload isKindOfClass:[NSDictionary class]]) {
+            NSDictionary * dict = (NSDictionary *)payload;
+            NSLog(@"finishedCallback: %@", dict);
+        } else {
+            NSLog(@"finishedCallback: %@", payload);
+        }
     };
 }
 


### PR DESCRIPTION
android is sending NSObject as finalPayLoad but iOS is sending a string, change `String` to `NSObject` on iOS