### PR TITLE
Support child fragment manager

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeReactFragmentActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeReactFragmentActivityDelegate.java
@@ -148,31 +148,45 @@ public class ElectrodeReactFragmentActivityDelegate extends ElectrodeReactActivi
     }
 
     public void startMiniAppFragment(@NonNull String componentName, @Nullable Bundle props) {
-        startMiniAppFragment(dataProvider.miniAppFragmentClass(), componentName, props);
+        StartMiniAppConfig config = new StartMiniAppConfig.Builder().fragmentClass(dataProvider.miniAppFragmentClass()).build();
+        startMiniAppFragment(componentName, props, config);
     }
 
+    /**
+     * @deprecated Start using {@link #startMiniAppFragment(String, Bundle, StartMiniAppConfig)}
+     */
+    @Deprecated
     public void startMiniAppFragment(@NonNull Class<? extends Fragment> fragmentClass, @NonNull String componentName, @Nullable Bundle props) {
+        StartMiniAppConfig config = new StartMiniAppConfig.Builder().fragmentClass(fragmentClass).build();
+        startMiniAppFragment(componentName, props, config);
+    }
+
+    public void startMiniAppFragment(@NonNull String componentName, @Nullable Bundle props, @NonNull StartMiniAppConfig startMiniAppConfig) {
         if (props == null) {
             props = new Bundle();
         }
         props.putString(ActivityDelegateConstants.KEY_MINI_APP_COMPONENT_NAME, componentName);
-        Logger.d(TAG, "startMiniAppFragment: fragmentClass->%s, componentName->%s, props->%s", fragmentClass.getSimpleName(), componentName, props);
-        switchToFragment(fragmentClass, props);
+
+        if (startMiniAppConfig.fragmentClass == null) {
+            throw new IllegalStateException("Should never reach here. At this point startMiniAppConfig should have a fragment class defined.");
+        }
+
+        Logger.d(TAG, "startMiniAppFragment: fragmentClass->%s, componentName->%s, props->%s", startMiniAppConfig.fragmentClass.getSimpleName(), componentName, props);
+
+        switchToFragment(props, ADD_TO_BACKSTACK, startMiniAppConfig);
     }
 
-    private void switchToFragment(@NonNull Class<?> fragmentClass, @NonNull Bundle bundle) {
-        switchToFragment(fragmentClass, bundle, ADD_TO_BACKSTACK);
-    }
-
-    private void switchToFragment(@NonNull Class<?> fragmentClass, @NonNull Bundle bundle,
-                                  @AddToBackStackState int addToBackStackState) {
+    private void switchToFragment(@NonNull Bundle bundle,
+                                  @AddToBackStackState int addToBackStackState, @NonNull StartMiniAppConfig startMiniAppConfig) {
         try {
-            Fragment fragment = (Fragment) fragmentClass.newInstance();
+            Fragment fragment = startMiniAppConfig.fragmentClass.newInstance();
 
             String tag = (bundle.containsKey(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_TAG)) ? bundle.getString(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_TAG) : bundle.getString(ActivityDelegateConstants.KEY_MINI_APP_COMPONENT_NAME);
             Logger.d(TAG, "Switching to a new fragment, tag: %s ", tag);
 
-            final FragmentTransaction transaction = mFragmentActivity.getSupportFragmentManager().beginTransaction();
+            final FragmentManager fragmentManager = startMiniAppConfig.fragmentManager != null ? startMiniAppConfig.fragmentManager : mFragmentActivity.getSupportFragmentManager();
+            final FragmentTransaction transaction = fragmentManager.beginTransaction();
+
             if (ADD_TO_BACKSTACK == addToBackStackState) {
                 transaction.addToBackStack(tag);
             }
@@ -181,7 +195,7 @@ public class ElectrodeReactFragmentActivityDelegate extends ElectrodeReactActivi
             transaction.replace(dataProvider.getFragmentContainerId(), fragment, tag);
             transaction.commit();
         } catch (Exception e) {
-            Logger.e(TAG, "Failed to create " + fragmentClass.getName() + " fragment", e);
+            Logger.e(TAG, "Failed to create " + startMiniAppConfig.fragmentClass.getName() + " fragment", e);
         }
     }
 
@@ -242,5 +256,39 @@ public class ElectrodeReactFragmentActivityDelegate extends ElectrodeReactActivi
          */
         @NonNull
         Class<? extends Fragment> miniAppFragmentClass();
+    }
+
+    /**
+     * Class that defines the custom configurations that can be passed while starting a new MiniApp fragment.
+     */
+    public static class StartMiniAppConfig {
+        @Nullable
+        final FragmentManager fragmentManager;
+        @Nullable
+        final Class<? extends Fragment> fragmentClass;
+
+        private StartMiniAppConfig(Builder builder) {
+            fragmentManager = builder.fragmentManager;
+            fragmentClass = builder.fragmentClass;
+        }
+
+        public static class Builder {
+            FragmentManager fragmentManager;
+            Class<? extends Fragment> fragmentClass;
+
+            public Builder fragmentManager(@Nullable FragmentManager fragmentManager) {
+                this.fragmentManager = fragmentManager;
+                return this;
+            }
+
+            public Builder fragmentClass(@NonNull Class<? extends Fragment> fragmentClass) {
+                this.fragmentClass = fragmentClass;
+                return this;
+            }
+
+            public StartMiniAppConfig build() {
+                return new StartMiniAppConfig(this);
+            }
+        }
     }
 }

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeReactFragmentActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeReactFragmentActivityDelegate.java
@@ -203,8 +203,7 @@ public class ElectrodeReactFragmentActivityDelegate extends ElectrodeReactActivi
             }
         }
 
-        boolean result = manager.popBackStackImmediate(tag, 0);
-        return result;
+        return manager.popBackStackImmediate(tag, 0);
     }
 
     public interface DataProvider {

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
@@ -20,7 +20,7 @@ import com.facebook.react.ReactRootView;
 
 import org.json.JSONObject;
 
-public abstract class ElectrodeBaseActivity extends AppCompatActivity implements ElectrodeReactFragmentActivityDelegate.DataProvider, MiniAppNavRequestListener {
+public abstract class ElectrodeBaseActivity extends AppCompatActivity implements ElectrodeReactFragmentActivityDelegate.DataProvider, MiniAppNavConfigRequestListener {
     public static final int DEFAULT_TITLE = -1;
 
     protected ElectrodeReactFragmentActivityDelegate mElectrodeReactNavDelegate;
@@ -168,6 +168,11 @@ public abstract class ElectrodeBaseActivity extends AppCompatActivity implements
     @Override
     public void startMiniAppFragment(@NonNull Class<? extends Fragment> fragmentClass, @NonNull String componentName, @Nullable Bundle props) {
         mElectrodeReactNavDelegate.startMiniAppFragment(fragmentClass, componentName, props);
+    }
+
+    @Override
+    public void startMiniAppFragment(@NonNull String componentName, @Nullable Bundle props, @NonNull ElectrodeReactFragmentActivityDelegate.StartMiniAppConfig startMiniAppConfig) {
+        mElectrodeReactNavDelegate.startMiniAppFragment(componentName, props, startMiniAppConfig);
     }
 
     @Nullable

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/MiniAppNavConfigRequestListener.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/MiniAppNavConfigRequestListener.java
@@ -1,0 +1,22 @@
+package com.ern.api.impl.navigation;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.ern.api.impl.core.ElectrodeReactFragmentActivityDelegate;
+
+/**
+ * Interface that exposes a way to provide more configuration while starting a MiniApp fragment.
+ */
+public interface MiniAppNavConfigRequestListener extends MiniAppNavRequestListener {
+
+    /**
+     * starts a new fragment and inflate it with the given react component.
+     *
+     * @param componentName react view component name.
+     * @param props         optional properties for the component rendering.
+     */
+    void startMiniAppFragment(@NonNull String componentName, @Nullable Bundle props, @NonNull ElectrodeReactFragmentActivityDelegate.StartMiniAppConfig startMiniAppConfig);
+}


### PR DESCRIPTION
This PR adds an important feature that allows more config options to be passed in when a new MiniApp Fragment is started. 

Today, the mini app fragment uses `activity.getFragmentManager()` to start a new MiniApp fragment. This limits the applications that uses `fragment.childFragmentManager()` to manage the back stack from using the navigation framework. With this change app that wants to use a `childFragmentManager` can do the following, 

in your Activity implement, `MiniAppNavConfigRequestListener.java ` instead of `MiniAppNavRequestListener.java`
and in the Fragment  implement `ElectrodeReactFragmentNavDelegate.UseChildFragmentManagerIndicator`. 
