### PR TITLE
pass globalProperties from native side, so it can be used for all the viewControllers

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Core/ENMiniAppDataProvider.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Core/ENMiniAppDataProvider.swift
@@ -19,4 +19,5 @@ import Foundation
 @objc public protocol ENMiniAppDataProvider: class {
     var rootComponentName: String { get }
     var properties: [AnyHashable : Any]? { get set }
+    @objc optional var globalProperties: [AnyHashable: Any]? { get set }
 }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -35,6 +35,7 @@ import UIKit
                     miniappVC.finishedCallback = finishedCallback
                 }
                 miniappVC.navigateWithRoute = vc.navigateWithRoute
+                miniappVC.globalProperties = vc.globalProperties ?? nil
                 navigationVC.navigationBar.isTranslucent = false
                 navigationVC.pushViewController(miniappVC, animated: false)
             }
@@ -103,7 +104,8 @@ import UIKit
             self.finishedCallBack(finalPayLoad: jsonPayLoad)
         } else {
             if !(self.viewController?.navigateWithRoute?(routeData) ?? false) {
-                let vc = MiniAppNavViewController(properties: routeData, miniAppName: path)
+                let combinedRouteData = self.combineRouteData(routeData: routeData, globalProperties: self.viewController?.globalProperties)
+                let vc = MiniAppNavViewController(properties: combinedRouteData, miniAppName: path)
                 if let navigationBarDict = routeData["navigationBar"] as? [AnyHashable: Any] {
                     let navBar = NavigationBar(dictionary: navigationBarDict)
                     vc.title = navBar.title
@@ -117,10 +119,18 @@ import UIKit
                     vc.finishedCallback = finishedCallback
                 }
                 vc.navigateWithRoute = self.viewController?.navigateWithRoute
+                vc.globalProperties = self.viewController?.globalProperties
                 self.viewController?.navigationController?.pushViewController(vc, animated: true)
             }
         }
         return completion("success")
+    }
+
+    private func combineRouteData(routeData: [AnyHashable: Any], globalProperties: [AnyHashable: Any]?) -> [AnyHashable: Any] {
+        guard let globalProps = globalProperties else {
+            return routeData
+        }
+        return routeData.merging(globalProps) {(current, _) in current }
     }
 
     func getNavBarTitle(title: String, viewController: UIViewController) {

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
@@ -18,11 +18,12 @@ import UIKit
 
 open class MiniAppNavViewController: UIViewController, ENNavigationProtocol {
     let miniAppName: String
-    let properties: [AnyHashable : Any]?
+    let properties: [AnyHashable: Any]?
     public var finishedCallback: MiniAppFinishedCallback?
     public var finish: Payload?
     var delegate: ENNavigationDelegate?
     public var navigateWithRoute: NavigateWithRoute?
+    public var globalProperties: [AnyHashable: Any]?
     public init(properties: [AnyHashable: Any]?, miniAppName: String) {
         self.miniAppName = miniAppName
         self.properties = properties


### PR DESCRIPTION
when we create viewController we'll use the combined the dictionary (dictionary from navigate call + globalProperties) as `properties` to create `MiniAppViewController`