### PR TITLE
Copy android resources to container

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,4 +11,3 @@ android/local.properties
 android/gradle*
 *.gradle
 *.png
-*.xml

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
         "dependencies": [
           "androidx.appcompat:appcompat:1.0.2",
           "androidx.lifecycle:lifecycle-extensions:2.0.0"
+        ],
+        "copy": [
+          {
+            "dest": "lib/src/main/res/devassist",
+            "source": "android/lib/src/main/res/values"
+          }
         ]
       },
       "ios": {


### PR DESCRIPTION
Update plugin injection configuration, by adding a `copy` directive, to copy the content of `values` resources directory (only containing `attrs.xml` resource file) to the container `devassist` resources directory.

This will end up in the following directory/file structure in `devassist` :

```
container/lib/src/main/res/
├── devassist
│   ├── values
│   │   ├── attrs.xml
│   │   └── strings.xml
│   └── xml
│       └── ern_dev_preferences.xml
```

This is a little hacky trick, that can't scale (so shouldn't be publicized) to have the resource properly packaged in the container, while waiting for a more proper way to inject android plugin resources in container (work in progress).

This PR also gets rids of the `*.xml` exclusion from the `.npmignore`, so that `attrs.xml` gets included in the npm package. 