### PR TITLE
Add script to update the import statement before and after publish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "dependencies": {
     "ernnavigation-api": "1.1.0"
   },
+  "scripts": {
+    "prepublishOnly": "node scripts/update-android-import.js './android/lib/src/main/java/com/ern/api/impl/navigation/views/MiniAppView.java' 'import com.walmartlabs.ern.navigation.R' 'import com.walmartlabs.ern.container.R'",
+    "postpublish": "node scripts/update-android-import.js './android/lib/src/main/java/com/ern/api/impl/navigation/views/MiniAppView.java' 'import com.walmartlabs.ern.container.R' 'import com.walmartlabs.ern.navigation.R'"
+  },
   "ern": {
     "containerGen": {
       "hasConfig": false,

--- a/scripts/update-android-import.js
+++ b/scripts/update-android-import.js
@@ -1,0 +1,18 @@
+var fs = require('fs')
+const args = process.argv.slice(2)
+ 
+const FILE = args[0]
+const REPLACE = args[1]
+const REPLACE_WITH = args[2]
+
+fs.readFile(FILE, 'utf8', (err, data) => {
+    if (err) {
+        console.error(`Updating import failed ${err}`)
+        return;
+    }
+    var result = data.replace(REPLACE, REPLACE_WITH);
+    fs.writeFile(FILE, result, 'utf8', function (err) {
+        if (err) return console.log(err);
+        console.log('Android import statement updated successfully.')
+    });
+})


### PR DESCRIPTION
This is done to support the android resource file reference copy over during container library generation by Electrode Native CLI