### PR TITLE
Add support for showing React Native components as an overlay in Android.

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ActivityDelegateConstants.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ActivityDelegateConstants.java
@@ -20,5 +20,6 @@ public class ActivityDelegateConstants {
     public static final String KEY_MINI_APP_COMPONENT_NAME = "miniAppComponentName";
     public static final String KEY_MINI_APP_FRAGMENT_TAG = "miniAppFragmentTag";
     public static final String KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED = "displayHomeAsUpEnabled";
+    public static final String KEY_FRAGMENT_TRANSACTION_REPLACE = "isReplaceFragment";
 }
 

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -89,8 +89,7 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
     @SuppressWarnings("unused")
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            mFragmentActivity.onBackPressed();
-            return true;
+            return onBackPressed();
         }
         return false;
     }

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -56,22 +56,26 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void onStart() {
+        Logger.v(TAG, "onStart()" + getMainComponentName());
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     @Override
     public void onResume() {
         super.onResume();
+        Logger.v(TAG, "onResume()");
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     @Override
     public void onPause() {
         super.onPause();
+        Logger.v(TAG, "onPause()");
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void onStop() {
+        Logger.v(TAG, "onStop()");
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
@@ -79,6 +83,7 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
     public void onDestroy() {
         mFragmentActivity = null;
         super.onDestroy();
+        Logger.v(TAG, "onDestroy()");
     }
 
     @SuppressWarnings("unused")

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -17,6 +17,7 @@ import androidx.lifecycle.OnLifecycleEvent;
 import com.walmartlabs.electrode.reactnative.bridge.helpers.Logger;
 import com.walmartlabs.ern.container.ElectrodeReactActivityDelegate;
 
+import static com.ern.api.impl.core.ActivityDelegateConstants.KEY_FRAGMENT_TRANSACTION_REPLACE;
 import static com.ern.api.impl.core.ElectrodeReactFragmentDelegate.MiniAppRequestListener.ADD_TO_BACKSTACK;
 
 public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegate implements LifecycleObserver {
@@ -145,8 +146,16 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
             }
 
             if (fragmentContainerId != LaunchConfig.NONE) {
-                Logger.d(TAG, "replacing fragment inside fragment container");
-                transaction.replace(fragmentContainerId, fragment, tag);
+                if (launchConfig.mShowAsOverlay) {
+                    Logger.d(TAG, "performing ADD fragment inside fragment container");
+                    transaction.add(fragmentContainerId, fragment, tag);
+                } else {
+                    Logger.d(TAG, "performing REPLACE fragment inside fragment container");
+                    if (fragment.getArguments() != null) {
+                        fragment.getArguments().putBoolean(KEY_FRAGMENT_TRANSACTION_REPLACE, true);
+                    }
+                    transaction.replace(fragmentContainerId, fragment, tag);
+                }
             } else {
                 throw new RuntimeException("Missing fragmentContainerId to add the " + fragment.getClass().getSimpleName() + ". Should never reach here.");
             }

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseFragmentDelegate.java
@@ -183,32 +183,37 @@ public class ElectrodeBaseFragmentDelegate<T extends ElectrodeBaseFragmentDelega
     @SuppressWarnings("unused")
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void onStart() {
+        Logger.v(TAG, "onStart(): " + getReactComponentName());
     }
 
     @SuppressWarnings("unused")
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     public void onResume() {
+        Logger.v(TAG, "onResume(): " + getReactComponentName());
     }
 
     @SuppressWarnings("unused")
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     public void onPause() {
+        Logger.v(TAG, "onPause(): " + getReactComponentName());
     }
 
     @SuppressWarnings("unused")
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     public void onStop() {
+        Logger.v(TAG, "onStop(): " + getReactComponentName());
     }
 
     @SuppressWarnings("unused")
     public void onDestroyView() {
+        Logger.v(TAG, "onDestroyView(): " + getReactComponentName());
     }
 
     @SuppressWarnings("unused")
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     @CallSuper
     public void onDestroy() {
-        Logger.v(TAG, "inside onDestroy");
+        Logger.v(TAG, "onDestroy(): " + getReactComponentName());
         if (mMiniAppView != null) {
             mElectrodeActivityListener.removeReactNativeView(mMiniAppComponentName, mMiniAppView);
             mMiniAppView = null;
@@ -217,6 +222,7 @@ public class ElectrodeBaseFragmentDelegate<T extends ElectrodeBaseFragmentDelega
 
     @SuppressWarnings("unused")
     public void onDetach() {
+        Logger.v(TAG, "onDetach(): " + getReactComponentName());
     }
 
     @NonNull

--- a/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
@@ -59,6 +59,12 @@ public class LaunchConfig {
     boolean mForceUpEnabled;
 
     /**
+     * Shows your next page view component as an overLay on top of the existing screen
+     * This flag is ignored if the component is the root component.
+     */
+    boolean mShowAsOverlay;
+
+    /**
      * Set this value to manage the fragment back stack
      */
     @AddToBackStackState
@@ -139,5 +145,15 @@ public class LaunchConfig {
      */
     public void setForceUpEnabled(boolean forceUpEnabled) {
         mForceUpEnabled = forceUpEnabled;
+    }
+
+    /**
+     * Shows your next page view component as an overLay on top of the existing screen
+     * This flag is ignored if the component is the root component.
+     *
+     * @param showAsOverlay true | false
+     */
+    public void setShowAsOverlay(boolean showAsOverlay) {
+        mShowAsOverlay = showAsOverlay;
     }
 }

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ComponentAsOverlay.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ComponentAsOverlay.java
@@ -1,0 +1,20 @@
+package com.ern.api.impl.navigation;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+/**
+ * Calling {@link androidx.fragment.app.FragmentTransaction#add(Fragment, String)} results in adding a new fragment to the stack with out putting the current fragment in stopped state.
+ * ComponentAsOverlay is introduced to handle this use case, where the currentFragment that starts an overlay will delegate the navigation requests using this interface.
+ *
+ * @see OverlayFragment, {@link ElectrodeNavigationFragmentDelegate#routeObserver}
+ */
+interface ComponentAsOverlay {
+    void navigate(@NonNull Route route);
+
+    void update(@NonNull Route route);
+
+    void back(@NonNull Route route);
+
+    void finish(@NonNull Route route);
+}

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/OverlayFragment.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/OverlayFragment.java
@@ -1,0 +1,26 @@
+package com.ern.api.impl.navigation;
+
+import androidx.annotation.NonNull;
+
+public class OverlayFragment extends MiniAppNavigationFragment implements ComponentAsOverlay {
+
+    @Override
+    public void navigate(@NonNull Route route) {
+        mElectrodeReactFragmentDelegate.navigate(route);
+    }
+
+    @Override
+    public void update(@NonNull Route route) {
+        mElectrodeReactFragmentDelegate.update(route);
+    }
+
+    @Override
+    public void back(@NonNull Route route) {
+        mElectrodeReactFragmentDelegate.back(route);
+    }
+
+    @Override
+    public void finish(@NonNull Route route) {
+        mElectrodeReactFragmentDelegate.finish(route);
+    }
+}


### PR DESCRIPTION
This PR adds support for showing a React Native component inside a transparent fragment.  This looks similar to a dialog fragment except that it would show the view component inside a fragment with a transparent background.  This gives more leverage for the React Native components to manage without knowing the details of any native implementation. 

The API currently being updated with the new overlay flag in this PR: https://github.com/electrode-io/ern-navigation-api/pull/8. This PR can be reviewed and merged as it does not look for the new flag yet. 

Best if reviews commit by commit. 