### PR TITLE
remove back button title

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -37,7 +37,7 @@ import UIKit
                 miniappVC.navigateWithRoute = vc.navigateWithRoute
                 miniappVC.globalProperties = vc.globalProperties ?? nil
                 navigationVC.navigationBar.isTranslucent = false
-                navigationVC.pushViewController(miniappVC, animated: false)
+                navigationVC.pushViewControllerWithoutBackButtonTitle(miniappVC, animated: false)
             }
         } else {
             super.viewDidLoad(viewController: viewController)
@@ -120,7 +120,7 @@ import UIKit
                 }
                 vc.navigateWithRoute = self.viewController?.navigateWithRoute
                 vc.globalProperties = self.viewController?.globalProperties
-                self.viewController?.navigationController?.pushViewController(vc, animated: true)
+                self.viewController?.navigationController?.pushViewControllerWithoutBackButtonTitle(vc, animated: true)
             }
         }
         return completion("success")

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
@@ -67,3 +67,10 @@ open class MiniAppNavViewController: UIViewController, ENNavigationProtocol {
         self.delegate?.updateNavigationBar(navBar: navBar, completion: completion)
     }
 }
+
+extension UINavigationController {
+    func pushViewControllerWithoutBackButtonTitle(_ viewController: UIViewController, animated: Bool = true) {
+        viewControllers.last?.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        pushViewController(viewController, animated: animated)
+    }
+}


### PR DESCRIPTION
Previously when we push a viewController to navigationController we show back button as arrow+title, we'll remove the title to keep it same as android
![Simulator Screen Shot - iPhone XR - 2019-12-04 at 11 00 42](https://user-images.githubusercontent.com/52257109/70172511-adc43580-1685-11ea-856d-c9ede08f1093.png) 
(before)
![Simulator Screen Shot - iPhone XR - 2019-12-04 at 10 58 35](https://user-images.githubusercontent.com/52257109/70172528-b3ba1680-1685-11ea-9b47-d97f4039e94e.png)
(after)
