### PR TITLE
delegate(ENNavigationProtocol) should be weak instead of strong

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -20,7 +20,7 @@ import UIKit
 
     static let buttonWidth: CGFloat = 22
     var navigationAPI: EnNavigationAPI?
-    var delegate: ENNavigationProtocol?
+    weak var delegate: ENNavigationProtocol?
 
     override public func viewDidLoad(viewController: UIViewController) {
         if let navigationVC = viewController as? UINavigationController {


### PR DESCRIPTION
delegate(ENNavigationProtocol) should be weak instead of strong, make the delegate to be weakly retained to fix the potential crash