### PR TITLE
Enable basic GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: main
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Electrode Native CLI
+        run: npm i -g electrode-native && ern
+      - name: Install dependencies
+        run: yarn
+      - name: Create and publish dev container
+        working-directory: android/
+        run: ./gradlew createAndPublishErnDevContainer


### PR DESCRIPTION
A very basic CI integration - At the moment only installing dependencies and building the Android code.

We should eventually expand this to also include iOS, tests, linting etc. For now,  these minimal CI steps should never fail.