### PR TITLE
Add androidx.swiperefreshlayout to android dependencies to support ba…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "root": "android",
         "dependencies": [
           "androidx.appcompat:appcompat:1.1.0",
-          "androidx.lifecycle:lifecycle-extensions:2.1.0"
+          "androidx.lifecycle:lifecycle-extensions:2.1.0",
+          "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
         ],
         "copy": [
           {


### PR DESCRIPTION
…ckward compatibility

This is because react-native@0.60.5 is still depending on this library and if we don't add it it fails the MiniApp when ran independently.