### PR TITLE
Enable root component launch customization.

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -49,10 +49,17 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (savedInstanceState == null) {
-            Logger.d(TAG, "Starting react native root component(%s). Loading the react view inside a fragment.", mRootComponentName);
-            startMiniAppFragment(mRootComponentName, mDefaultLaunchConfig);
+        if (savedInstanceState == null && mDefaultLaunchConfig.startRootInOnCreate) {
+            launchRootComponent();
         }
+    }
+
+    /**
+     * Replaces the current fragment with the root component.
+     */
+    public void launchRootComponent() {
+        Logger.d(TAG, "Starting react native root component(%s). Loading the react view inside a fragment.", mRootComponentName);
+        startMiniAppFragment(mRootComponentName, mDefaultLaunchConfig);
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)

--- a/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
@@ -70,6 +70,11 @@ public class LaunchConfig {
     @AddToBackStackState
     int mAddToBackStack = ADD_TO_BACK_STACK;
 
+    /**
+     * Decides of the root component needs to be launched when the activity delegates onCreate is called.
+     */
+    boolean startRootInOnCreate = true;
+
     public LaunchConfig() {
     }
 
@@ -159,5 +164,24 @@ public class LaunchConfig {
 
     public boolean isShowAsOverlay() {
         return mShowAsOverlay;
+    }
+
+    /**
+     * Decides of the root component needs to be launched when the activity delegates onCreate is called.
+     * This is typically set when application/activity needs to take control of when the root component fragment needs to be started.
+     *
+     * @param startRootInOnCreate true | false Default value: true
+     */
+    public void setStartRootInOnCreate(boolean startRootInOnCreate) {
+        this.startRootInOnCreate = startRootInOnCreate;
+    }
+
+    /**
+     * Decides of the root component needs to be launched when the activity delegates onCreate is called.
+     * This is typically set when application/activity needs to take control of when the root component fragment needs to be started.
+     */
+
+    public boolean isStartRootInOnCreate() {
+        return startRootInOnCreate;
     }
 }


### PR DESCRIPTION
This allows hosting activity to control when the root component can be launched instead of force launching it in onCreate.