### PR TITLE
iOS - add native implementation for NavigationBarLeftButton

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBarButtonItem.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBarButtonItem.swift
@@ -19,3 +19,7 @@ import UIKit
 class ENBarButtonItem: UIBarButtonItem {
     var stringTag: String?
 }
+
+class ENBarLeftButtonItem: ENBarButtonItem {
+    var currViewController: UIViewController?
+}


### PR DESCRIPTION
NavigationButton(location: left) is deprecated, it will only be used for right buttons only.
NavigationBarLeftButton will be used for left navigation button.