### PR TITLE
Do not disable up navigation when the enabled flag is false.

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -373,11 +373,11 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
                 }
             }
 
-            if (mFragment.getArguments() != null) {
-                //Default action
+            //Default action
+            if (mFragment.getArguments() != null && mFragment.getArguments().getBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED)) {
                 Logger.d(TAG, "Defaulting DisplayHomeAsUp indicator for component: %s", getReactComponentName());
                 supportActionBar.setHomeAsUpIndicator(0);
-                supportActionBar.setDisplayHomeAsUpEnabled(mFragment.getArguments().getBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED));
+                supportActionBar.setDisplayHomeAsUpEnabled(true);
             }
         } else {
             Logger.i(TAG, "Action bar is null, skipping updateHomeAsUpIndicator");


### PR DESCRIPTION
Assuming enabled=false is not an indication that it is disabled as the native app my have overridden the control.