### PR TITLE
Remove getMainComponentName() as this is only introduced after 0.59.9…

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -64,7 +64,7 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     public void onStart() {
-        Logger.v(TAG, "onStart()" + getMainComponentName());
+        Logger.v(TAG, "onStart(): " + mRootComponentName);
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)


### PR DESCRIPTION
… of React Native