### PR TITLE
force update the view in the `back` call (refresh == true)

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
@@ -57,7 +57,8 @@ import UIKit
 
     func reloadView(viewController: UIViewController, ernNavRoute: [AnyHashable: Any]?) {
         if let v = self.rnView, let miniAppVC = viewController as? MiniAppNavViewController {
-            let combinedProperties = self.combineRouteData(dictionary1: miniAppVC.properties, dictionary2: ernNavRoute)
+            var combinedProperties = self.combineRouteData(dictionary1: miniAppVC.properties, dictionary2: ernNavRoute)
+            combinedProperties?["timestamp"] = Date()
             guard let combinedProps = combinedProperties else {
                 return
             }


### PR DESCRIPTION
added a timestamp in rnView initial props, so when going back to the previous page, react native could update the view every time.