### PR TITLE
Allow iOS navigation bar icons to fallback on named image assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ernnavigation-api-impl-native",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "license": "Apache-2.0",
   "dependencies": {
     "ernnavigation-api": "1.2.1"


### PR DESCRIPTION
This fixes https://github.com/electrode-io/ernnavigation-api-impl-native/issues/91