### PR TITLE
Register the request handlers soon after view model registration

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -166,6 +166,7 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
         if (args != null && args.getBoolean(ActivityDelegateConstants.KEY_REGISTER_NAV_VIEW_MODEL)) {
             mNavViewModel = ViewModelProviders.of(mFragment).get(ReactNavigationViewModel.class);
             mNavViewModel.getRouteLiveData().observe(mFragment.getViewLifecycleOwner(), routeObserver);
+            mNavViewModel.registerNavRequestHandler();
         }
     }
 

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ReactNavigationViewModel.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ReactNavigationViewModel.java
@@ -158,8 +158,6 @@ public final class ReactNavigationViewModel extends ViewModel {
             updateRequestHandle = EnNavigationApi.requests().registerUpdateRequestHandler(updateRequestHandler);
             backRequestHandle = EnNavigationApi.requests().registerBackRequestHandler(backRequestHandler);
             finishRequestHandle = EnNavigationApi.requests().registerFinishRequestHandler(finishRequestHandler);
-        } else {
-            throw new IllegalStateException("Trying to register when there is an active request handler present. Call unregister first before registering a new instance.");
         }
     }
 


### PR DESCRIPTION
This is required to avoid race conditions where a react native view gets created before fragment's onResume is called