### PR TITLE
make viewIdentifier public in ENCoreDelegate

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
@@ -18,7 +18,7 @@ import UIKit
 
 @objcMembers public class ENCoreDelegate: NSObject {
     var viewController: MiniAppNavViewController?
-    var viewIdentifier: String = "NOT_SET"
+    public var viewIdentifier: String = "NOT_SET"
     static let KEY_UNIQUE_VIEW_IDENTIFIER = "viewId"
     var rnView: UIView?
 


### PR DESCRIPTION
make viewIdentifier public in ENCoreDelegate so that we can access it outside ElectrodeContainer