### PR TITLE
Hide the up indicator icon based on launch config

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ActivityDelegateConstants.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ActivityDelegateConstants.java
@@ -20,6 +20,7 @@ public class ActivityDelegateConstants {
     public static final String KEY_MINI_APP_COMPONENT_NAME = "miniAppComponentName";
     public static final String KEY_MINI_APP_FRAGMENT_TAG = "miniAppFragmentTag";
     public static final String KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED = "displayHomeAsUpEnabled";
+    public static final String KEY_MINI_APP_FRAGMENT_HIDE_UP_INDICATOR = "hideUpIndicatorIcon";
     public static final String KEY_REGISTER_NAV_VIEW_MODEL = "shouldRegisterNavViewModel";
 }
 

--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -136,6 +136,9 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
         Bundle props = launchConfig.mInitialProps != null ? launchConfig.mInitialProps : new Bundle();
         props.putString(ActivityDelegateConstants.KEY_MINI_APP_COMPONENT_NAME, componentName);
         props.putBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED, shouldShowUpEnabled(launchConfig.mForceUpEnabled));
+        if (!launchConfig.mForceUpEnabled) {
+            props.putBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_HIDE_UP_INDICATOR, launchConfig.mHideUpIndicatorIcon);
+        }
         fragment.setArguments(props);
 
         Logger.d(TAG, "starting fragment: fragmentClass->%s, props->%s", fragment.getClass().getSimpleName(), props);

--- a/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
@@ -59,6 +59,11 @@ public class LaunchConfig {
     boolean mForceUpEnabled;
 
     /**
+     * Set this to true if you want to hide the up indicator for a component
+     */
+    boolean mHideUpIndicatorIcon;
+
+    /**
      * Shows your next page view component as an overLay on top of the existing screen
      * This flag is ignored if the component is the root component.
      */
@@ -155,6 +160,23 @@ public class LaunchConfig {
      */
     public void setForceUpEnabled(boolean forceUpEnabled) {
         mForceUpEnabled = forceUpEnabled;
+    }
+
+    /**
+     * Set this to true will hide the up indicator for a given page.
+     * Setting this to false will do nothing but falling back to the default ActionBar behavior.
+     * i.e, if the app bar has an icon then it will show up and vice versa.
+     */
+    public void setHideUpIndicatorIcon(boolean mHideUpIndicatorIcon) {
+        this.mHideUpIndicatorIcon = mHideUpIndicatorIcon;
+    }
+
+    /**
+     * Should hide up indicator for a component
+     * * @return true | false
+     */
+    public boolean isHideUpIndicatorIcon() {
+        return mHideUpIndicatorIcon;
     }
 
     /**

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
@@ -106,6 +106,7 @@ public abstract class ElectrodeBaseActivity extends AppCompatActivity implements
         defaultLaunchConfig.setFragmentContainerId(getFragmentContainerId());
         defaultLaunchConfig.setFragmentManager(getSupportFragmentManager());
         defaultLaunchConfig.updateInitialProps(getProps());
+        defaultLaunchConfig.setHideUpIndicatorIcon(true);
         return defaultLaunchConfig;
     }
 

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -383,10 +383,15 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
             }
 
             //Default action
-            if (mFragment.getArguments() != null && mFragment.getArguments().getBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED)) {
-                Logger.d(TAG, "Defaulting up indicator for component: %s", getReactComponentName());
-                supportActionBar.setHomeAsUpIndicator(0);
-                supportActionBar.setDisplayHomeAsUpEnabled(true);
+            if (mFragment.getArguments() != null) {
+                if (mFragment.getArguments().getBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_SHOW_UP_ENABLED)) {
+                    Logger.d(TAG, "Enabling up indicator for component: %s", getReactComponentName());
+                    supportActionBar.setHomeAsUpIndicator(0);
+                    supportActionBar.setDisplayHomeAsUpEnabled(true);
+                } else if (mFragment.getArguments().getBoolean(ActivityDelegateConstants.KEY_MINI_APP_FRAGMENT_HIDE_UP_INDICATOR)) {
+                    Logger.d(TAG, "Hiding up indicator for component: %s", getReactComponentName());
+                    supportActionBar.setDisplayHomeAsUpEnabled(false);
+                }
             }
         } else {
             Logger.i(TAG, "Action bar is null, skipping updateHomeAsUpIndicator");


### PR DESCRIPTION
This PR fixes an issue where the up indicator was showing up when navigating back to a root page. This was because of the shared action bar instance between fragments and every fragment navigation needs to make sure the navbar is properly reset. 