### PR TITLE
Allow replace fragment while navigating to a new page

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/ElectrodeBaseActivityDelegate.java
@@ -175,6 +175,9 @@ public class ElectrodeBaseActivityDelegate extends ElectrodeReactActivityDelegat
             } else {
                 throw new RuntimeException("Missing fragmentContainerId to add the " + fragment.getClass().getSimpleName() + ". Should never reach here.");
             }
+            if (launchConfig.mReplace && fragmentManager.getBackStackEntryCount() > 0) {
+                fragmentManager.popBackStackImmediate();
+            }
             transaction.commit();
             Logger.d(TAG, "startMiniAppFragment completed successfully.");
         }

--- a/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
+++ b/android/lib/src/main/java/com/ern/api/impl/core/LaunchConfig.java
@@ -85,6 +85,12 @@ public class LaunchConfig {
      */
     boolean mRootBackPressHandledByRN;
 
+    /**
+     * Indicates if a new fragment/page should replace the current visible fragment.
+     * This is valid only when the backStackEntryCount is > 0.
+     */
+    boolean mReplace;
+
     public LaunchConfig() {
     }
 
@@ -228,5 +234,22 @@ public class LaunchConfig {
      */
     public boolean isRootBackPressHandledByRN() {
         return mRootBackPressHandledByRN;
+    }
+
+    /**
+     * Set to true when you want the next fragment in the navigation stack to replace the current one
+     *
+     * @param replace true | false
+     */
+    public void setReplace(boolean replace) {
+        mReplace = replace;
+    }
+
+    /**
+     * Indicates if a new fragment/page should replace the current visible fragment.
+     * This is valid only when the backStackEntryCount is > 0.
+     */
+    public boolean shouldReplace() {
+        return mReplace;
     }
 }

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -284,10 +284,10 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
      */
     protected LaunchConfig createNextLaunchConfig(@NonNull Route route) {
         LaunchConfig config = new LaunchConfig();
-        boolean showAsOverlay = route.getArguments().getBoolean("overlay");
         config.updateInitialProps(route.getArguments());
         config.setFragmentManager(mFragmentConfig != null && mFragmentConfig.mUseChildFragmentManager ? mFragment.getChildFragmentManager() : null);
-        config.setShowAsOverlay(showAsOverlay);
+        config.setShowAsOverlay(route.getArguments().getBoolean("overlay", false));
+        config.setReplace(route.getArguments().getBoolean("replace", false));
         return config;
     }
 


### PR DESCRIPTION
This PR adds a new feature to the Android side to allow replacing an existing fragment with a new one. 