### PR TITLE
Finish flow: cleanup and set proper delegate

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -108,11 +108,22 @@ import UIKit
         guard let navController = self.viewController?.navigationController else { return }
         for vc in navController.viewControllers {
             (vc as? MiniAppNavViewController)?.delegate?.deinitRNView()
+            (vc as? MiniAppNavViewController)?.delegate = nil
         }
         if ((self.viewController?.finish) != nil) {
             self.viewController?.finish?(payloadDict)
         } else {
             self.finishedCallBack(finalPayLoad: finalPayload)
+        }
+        var presentingVC: UIViewController? = self.viewController
+        while presentingVC?.presentingViewController != nil {
+            presentingVC = presentingVC?.presentingViewController
+            if let nc = presentingVC as? UINavigationController {
+                if let miniappVC = nc.viewControllers.last as? MiniAppNavViewController {
+                    ENNavigationAPIImpl.shared.delegate = miniappVC
+                    break;
+                }
+            }
         }
         return completion("Finished status")
     }


### PR DESCRIPTION
Clears delegate on miniapp that calls finish.

Also sets delegate of ENNavigationAPIImpl.shared to proper MiniAppViewController. Delegate can get out of sync with presenting and dismissing modal view controllers.