### PR TITLE
Allow RN component to handle back even if the nav bar is hidden

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -379,13 +379,14 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
                 mActionBarStatusViewModel.hiddenByRn = true;
                 actionBar.hide();
             }
-            return;
         } else if (mActionBarStatusViewModel.hiddenByRn && !actionBar.isShowing()) {
             // Show only if the action bar was hidden by RN component when it was visible.
             // This makes sure that this logic  will not turn back on the action bar that was hidden by Native.
             actionBar.show();
+            mActionBarStatusViewModel.hiddenByRn = false;
+        } else {
+            mActionBarStatusViewModel.hiddenByRn = false;
         }
-        mActionBarStatusViewModel.hiddenByRn = false;
 
         actionBar.setTitle(navigationBar.getTitle());
 


### PR DESCRIPTION
This allows Rect Native to take control of the device back press when the Navigation Bar is hidden.