### PR TITLE
Refactor overlay related changes

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBarButtonItem.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBarButtonItem.swift
@@ -18,7 +18,7 @@ import UIKit
 
 class ENBarButtonItem: UIBarButtonItem {
     var stringTag: String?
-    var currViewController: UIViewController?
+    var viewController: UIViewController? // Need reference here to get access to presenting VC for overlay use case
 }
 
 enum NavEventType: String {

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationAPIImpl.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationAPIImpl.swift
@@ -46,7 +46,12 @@ class ENNavigationAPIImpl: NSObject {
                 if let navBarDict = ernData["navigationBar"] as? [AnyHashable : Any] {
                     let navBar = NavigationBar(dictionary: navBarDict)
                     self.delegate?.updateNavigationBar(navBar: navBar, completion: { (message) in
-                        return block(message, nil)
+                        if message == "success" {
+                            return block(message, nil)
+                        } else {
+                            let failureMessage = ElectrodeBridgeFailureMessage.createFailureMessage(withCode: "error", message: message)
+                            return block(nil, failureMessage)
+                        }
                     })
                 }
             }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENOverlayProtocol.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENOverlayProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ENOverlayProtocol.swift
+//  ElectrodeContainer
+//
+//  Created by Jeffrey Wang on 8/5/20.
+//  Copyright © 2020 Walmart. All rights reserved.
+//
+
+import Foundation
+
+protocol ENOverlayProtocol: class {
+    func onDismissOverlay() // Previous overlay is dismissed, use this method to restore state, ie: navigation bar state
+}

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-open class MiniAppNavViewController: UIViewController, ENNavigationProtocol {
+open class MiniAppNavViewController: UIViewController, ENNavigationProtocol, ENOverlayProtocol {
     let miniAppName: String
     var properties: [AnyHashable: Any]?
     public var finishedCallback: MiniAppFinishedCallback?
@@ -82,6 +82,10 @@ open class MiniAppNavViewController: UIViewController, ENNavigationProtocol {
     func updateNavigationBar(navBar: NavigationBar, completion: @escaping ERNNavigationCompletionBlock) {
         self.properties?["navigationBar"] = navBar.toDictionary()
         self.delegate?.updateNavigationBar(navBar: navBar, completion: completion)
+    }
+
+    func onDismissOverlay() {
+        self.delegate?.onDismissOverlay()
     }
 
     func hideNavigationBarIfNeeded() {


### PR DESCRIPTION
Refactors include 

- removing viewcontroller from parameters of methods inside navigation delegate, since one already has a reference to viewcontroller from delegate.
- delegating on dismiss flow for overly use case 
- renaming of some methods and properties to more accurately describe intent

Also fixes issues with left button where left button state was not correct after dismissing overlays by saving left bar button state