### PR TITLE
Handle replace when presenting overlays

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENOverlayProtocol.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENOverlayProtocol.swift
@@ -17,5 +17,6 @@
 import Foundation
 
 protocol ENOverlayProtocol: class {
+    func presentOverlay(viewToPresent: UIViewController) // Use this method to display overlay
     func onDismissOverlay() // Previous overlay is dismissed, use this method to restore state, ie: navigation bar state
 }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/MiniAppNavViewController.swift
@@ -85,6 +85,10 @@ open class MiniAppNavViewController: UIViewController, ENNavigationProtocol, ENO
         self.delegate?.updateNavigationBar(navBar: navBar, completion: completion)
     }
 
+    func presentOverlay(viewToPresent: UIViewController) {
+        self.delegate?.presentOverlay(viewToPresent: viewToPresent)
+    }
+
     func onDismissOverlay() {
         self.delegate?.onDismissOverlay()
     }


### PR DESCRIPTION
If replacing overlay with overlay, dismiss first overlay and then present.

If replacing overlay with non-overlay, dismiss and then present without replacing.