### PR TITLE
Fix top fragment fetch

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
@@ -1,7 +1,6 @@
 package com.ern.api.impl.navigation;
 
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MenuItem;
@@ -12,7 +11,6 @@ import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -283,12 +283,20 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
         return config;
     }
 
+    /**
+     * This method should return the fragment that is hosting the current RN view.
+     *
+     * @return Fragment
+     */
     @Nullable
     protected Fragment getTopOfTheStackFragment() {
         if (mFragment.getActivity() != null) {
             List<Fragment> fragments = mFragment.getActivity().getSupportFragmentManager().getFragments();
-            if (fragments.size() > 0) {
-                return fragments.get(fragments.size() - 1);
+            for (int i = fragments.size() - 1; i >= 0; i--) {
+                Fragment f = fragments.get(i);
+                if (f == mFragment || f instanceof NavigationRouteHandler) {
+                    return f;
+                }
             }
         }
         return null;


### PR DESCRIPTION
this allows a navigate request to get the right fragment instance even if the activity has made a dialog visible on top. 