### PR TITLE
Override all methods of PermissionAwareActivity

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeBaseActivity.java
@@ -263,4 +263,14 @@ public abstract class ElectrodeBaseActivity extends AppCompatActivity implements
         mElectrodeReactNavDelegate.onRequestPermissionsResult(
                 requestCode, permissions, grantResults);
     }
+
+    @Override
+    public int checkSelfPermission(String permission) {
+        return super.checkSelfPermission(permission);
+    }
+
+    @Override
+    public int checkPermission(String permission, int pid, int uid) {
+        return super.checkPermission(permission, pid, uid);
+    }
 }


### PR DESCRIPTION
This helps consumer apps to not to worry about PermissionAwareActivity visibility