### PR TITLE
Rename ENNavigationProtocol instance and remove unnecessary property

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationAPIImpl.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationAPIImpl.swift
@@ -19,7 +19,7 @@ import Foundation
 class ENNavigationAPIImpl: NSObject {
     static let shared = ENNavigationAPIImpl()
     let navigationAPI: EnNavigationAPI
-    weak var delegate: ENNavigationProtocol?
+    weak var currentViewController: ENNavigationProtocol?
 
     private override init() {
         self.navigationAPI = EnNavigationAPI()
@@ -33,7 +33,7 @@ class ENNavigationAPIImpl: NSObject {
     func registerFinishRequestHandler() {
         _ = self.navigationAPI.requests.registerFinishRequestHandler(handler: { (data, block) in
             let finishFlow = data as? String
-            self.delegate?.handleFinishFlow(finalPayLoad: finishFlow, completion: { (messageCompletion) in
+            self.currentViewController?.handleFinishFlow(finalPayLoad: finishFlow, completion: { (messageCompletion) in
                 block(messageCompletion, nil)
                 return
             })
@@ -45,7 +45,7 @@ class ENNavigationAPIImpl: NSObject {
             if let d = data as? ErnNavRoute, let ernData = d.toDictionary() as? [AnyHashable : Any] {
                 if let navBarDict = ernData["navigationBar"] as? [AnyHashable : Any] {
                     let navBar = NavigationBar(dictionary: navBarDict)
-                    self.delegate?.updateNavigationBar(navBar: navBar, completion: { (message) in
+                    self.currentViewController?.updateNavigationBar(navBar: navBar, completion: { (message) in
                         if message == "success" {
                             return block(message, nil)
                         } else {
@@ -62,7 +62,7 @@ class ENNavigationAPIImpl: NSObject {
         _ = self.navigationAPI.requests.registerBackRequestHandler(handler: { (data, block) in
             let d = data as? ErnNavRoute
             let ernData = d?.toDictionary() as? [AnyHashable : Any]
-            self.delegate?.popToViewControllerWithPath(ernNavRoute: ernData, completion: { (message) in
+            self.currentViewController?.popToViewControllerWithPath(ernNavRoute: ernData, completion: { (message) in
                 if message == "success" {
                     return block(message, nil)
                 } else {
@@ -76,7 +76,7 @@ class ENNavigationAPIImpl: NSObject {
     func registerNavigationRequestHandler() {
         _ = self.navigationAPI.requests.registerNavigateRequestHandler(handler: { (data, block) in
             if let d = data as? ErnNavRoute, let ernData = d.toDictionary() as? [AnyHashable : Any] {
-                self.delegate?.handleNavigationRequestWithPath(routeData: ernData, completion: { (message) in
+                self.currentViewController?.handleNavigationRequestWithPath(routeData: ernData, completion: { (message) in
                     return block(message, nil)
                 })
             }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -21,11 +21,9 @@ import UIKit
     static let buttonWidth: CGFloat = 22
     static var hiddenByRn: Bool = false
     var navigationAPI: EnNavigationAPI?
-    weak var delegate: ENNavigationProtocol?
     var navBarState: ENNavigationBarState?
 
     override public func viewDidLoad(viewController: UIViewController) {
-        self.delegate = viewController as? ENNavigationProtocol
         if let navigationVC = viewController as? UINavigationController {
             if let vc = navigationVC as? ENMiniAppNavDataProvider {
                 let miniAppName = vc.rootComponentName
@@ -52,7 +50,7 @@ import UIKit
     func viewWillAppear() {
         if let vc = self.viewController {
             vc.hideNavigationBarIfNeeded()
-            ENNavigationAPIImpl.shared.delegate = vc
+            ENNavigationAPIImpl.shared.currentViewController = vc
         }
     }
 
@@ -176,7 +174,7 @@ import UIKit
             presentingVC = presentingVC?.presentingViewController
             if let nc = presentingVC as? UINavigationController {
                 if let miniappVC = nc.viewControllers.last as? MiniAppNavViewController {
-                    ENNavigationAPIImpl.shared.delegate = miniappVC
+                    ENNavigationAPIImpl.shared.currentViewController = miniappVC
                     break;
                 }
             }
@@ -189,7 +187,7 @@ import UIKit
             vc.navigationController?.navigationBar.topItem?.title = vc.delegate?.navBarState?.title
             vc.navigationController?.navigationBar.topItem?.leftBarButtonItem = vc.delegate?.navBarState?.leftBarButtonItem
             vc.navigationController?.navigationBar.topItem?.rightBarButtonItems = vc.delegate?.navBarState?.rightBarButtonItems
-            ENNavigationAPIImpl.shared.delegate = vc
+            ENNavigationAPIImpl.shared.currentViewController = vc
         }
     }
     func updateNavigationBar(navBar: NavigationBar, completion: @escaping ERNNavigationCompletionBlock) {


### PR DESCRIPTION
@deepueg wanted to rename the instance of ENNavigationProtocol so as to not confuse it with ENNavigationDelegate.

Not sure if this name is appropriate (currentViewController)

Also, I noticed that the property delegate in ENNavigationDelegate is set and never used, so I'm removing it.