### PR TITLE
Keep nav request handlers when app is backgrounded

### DIFF
--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationActivityDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationActivityDelegate.java
@@ -49,10 +49,10 @@ public class ElectrodeNavigationActivityDelegate extends ElectrodeBaseActivityDe
         }
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     @Override
-    public void onPause() {
-        super.onPause();
+    public void onDestroy() {
+        super.onDestroy();
         if (mDefaultLaunchConfig.mUseActivityScopedNavigation && mNavViewModel != null) {
             mNavViewModel.unRegisterNavRequestHandler();
         }

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -200,17 +200,15 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
     @CallSuper
     public void onPause() {
         super.onPause();
-        if (mNavViewModel != null) {
-            mNavViewModel.unRegisterNavRequestHandler();
-        }
         EnNavigationApi.events().emitNavEvent(new NavEventData.Builder(NavEventType.DID_BLUR.toString()).viewId(getMiniAppViewIdentifier()).build());
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-        if (mMenu != null) {
-            mMenu = null;
+        mMenu = null;
+        if (mNavViewModel != null) {
+            mNavViewModel.unRegisterNavRequestHandler();
         }
         mFragmentNavigator = null;
     }

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ReactNavigationViewModel.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ReactNavigationViewModel.java
@@ -152,7 +152,7 @@ public final class ReactNavigationViewModel extends ViewModel {
     private RequestHandlerHandle finishRequestHandle;
 
     public void registerNavRequestHandler() {
-        if (requestHandle == null) {
+        if (requestHandle == null || !requestHandle.isRegistered()) {
             log("Registering navigation request handlers");
             requestHandle = EnNavigationApi.requests().registerNavigateRequestHandler(navRequestHandler);
             updateRequestHandle = EnNavigationApi.requests().registerUpdateRequestHandler(updateRequestHandler);


### PR DESCRIPTION
This allows RN components to call all the navigate apis even when the app is backgrounded.