### PR TITLE
Enable GitHub Actions publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: '*'
+  pull_request:
 jobs:
   build-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: publish
+on:
+  push:
+    tags: v[0-9]+.[0-9]+.[0-9]+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn --frozen-lockfile
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This enables publishing of new releases to npm via GitHub Actions, reducing the "manual" steps to two simple commands:

1. `npm version <major|minor|patch>`
2. `git push --follow-tags`

The first command updates the version in `package.json`, commits the changes, and creates a tag. The second command pushes both the commit and tag in a single operation. That's it!

Once GitHub Actions sees a new version tag, it will take care of the rest: Publishing the new version to npm. The required token (`NPM_TOKEN`) has already been added to this repo.