### PR TITLE
Fix back bug

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -135,9 +135,13 @@ import UIKit
             return completion("cannot find path from viewController stack")
         } else {
             if let navigationController = viewController?.navigationController {
-                navigationController.popViewController(animated: true)
-                if refresh, let lastVC = navigationController.viewControllers.last, let miniAppVC = lastVC as? MiniAppNavViewController {
-                    miniAppVC.reloadView(ernNavRoute: ernNavRoute)
+                if navigationController.viewControllers.count == 1 {
+                    navigationController.dismiss(animated: true, completion: nil)
+                } else {
+                    navigationController.popViewController(animated: true)
+                    if refresh, let lastVC = navigationController.viewControllers.last, let miniAppVC = lastVC as? MiniAppNavViewController {
+                        miniAppVC.reloadView(ernNavRoute: ernNavRoute)
+                    }
                 }
             }
             return completion("success")


### PR DESCRIPTION
Calling back on a navigation controller with only 1 viewcontroller should dismiss the navigation controller. Current implementation only calls pop, which will do nothing when there is only 1 view controller.