### PR TITLE
Backto bug fixes: namepsace error on base class, json merging bug

### DIFF
--- a/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
+++ b/ios/ElectrodeApiImpl.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		6E948F122602991F00E99E37 /* MiniAppNavViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E948EEA2602991F00E99E37 /* MiniAppNavViewController.swift */; };
 		6E948F132602991F00E99E37 /* RequestHandlerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E948EEB2602991F00E99E37 /* RequestHandlerProvider.swift */; };
 		6E948F142602991F00E99E37 /* RequestHandlerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E948EEC2602991F00E99E37 /* RequestHandlerConfig.swift */; };
+		6EA337DB263CC60C00612B5B /* ENNavigationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA337C1263CC60C00612B5B /* ENNavigationUtils.swift */; };
 		6ED8270723D7C2EC00A0CEE9 /* EnNavigationEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED8270023D7C2EC00A0CEE9 /* EnNavigationEvents.swift */; };
 		6ED8270823D7C2EC00A0CEE9 /* NavigationBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED8270123D7C2EC00A0CEE9 /* NavigationBarButton.swift */; };
 		6ED8270923D7C2EC00A0CEE9 /* NavigationBarLeftButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED8270223D7C2EC00A0CEE9 /* NavigationBarLeftButton.swift */; };
@@ -503,6 +504,7 @@
 		6E948EEA2602991F00E99E37 /* MiniAppNavViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniAppNavViewController.swift; sourceTree = "<group>"; };
 		6E948EEB2602991F00E99E37 /* RequestHandlerProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestHandlerProvider.swift; sourceTree = "<group>"; };
 		6E948EEC2602991F00E99E37 /* RequestHandlerConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestHandlerConfig.swift; sourceTree = "<group>"; };
+		6EA337C1263CC60C00612B5B /* ENNavigationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ENNavigationUtils.swift; sourceTree = "<group>"; };
 		6ED8270023D7C2EC00A0CEE9 /* EnNavigationEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnNavigationEvents.swift; path = container/ElectrodeContainer/APIs/EnNavigationEvents.swift; sourceTree = SOURCE_ROOT; };
 		6ED8270123D7C2EC00A0CEE9 /* NavigationBarButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationBarButton.swift; path = container/ElectrodeContainer/APIs/NavigationBarButton.swift; sourceTree = SOURCE_ROOT; };
 		6ED8270223D7C2EC00A0CEE9 /* NavigationBarLeftButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NavigationBarLeftButton.swift; path = container/ElectrodeContainer/APIs/NavigationBarLeftButton.swift; sourceTree = SOURCE_ROOT; };
@@ -760,6 +762,7 @@
 				6E948EE42602991F00E99E37 /* ENNavigationBarState.swift */,
 				6E948EE32602991F00E99E37 /* ENNavigationDelegate.swift */,
 				6E948EE72602991F00E99E37 /* ENNavigationProtocol.swift */,
+				6EA337C1263CC60C00612B5B /* ENNavigationUtils.swift */,
 				6E948EE62602991F00E99E37 /* ENOverlayProtocol.swift */,
 				6E948EEA2602991F00E99E37 /* MiniAppNavViewController.swift */,
 			);
@@ -1388,6 +1391,7 @@
 				6ED8270723D7C2EC00A0CEE9 /* EnNavigationEvents.swift in Sources */,
 				49398F13519C493BAB5B79AF /* Processor.swift in Sources */,
 				82CBA81827F6428C840A8210 /* None.swift in Sources */,
+				6EA337DB263CC60C00612B5B /* ENNavigationUtils.swift in Sources */,
 				96984CA17C8F4B5B962D5E78 /* ElectrodeBridgeEvent.m in Sources */,
 				6E948F0D2602991F00E99E37 /* ENNavigationAPIImpl.swift in Sources */,
 				A19374775C014A0F8683C6CA /* ElectrodeBridgeFailureMessage.m in Sources */,

--- a/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
@@ -77,7 +77,22 @@ import UIKit
         guard let dict2 = dictionary2 else {
             return dictionary1
         }
-        return dict2.merging(dict1) {(current, _) in current }
+
+        var result = dict2.merging(dict1) {(current, _) in current }
+
+        /*  When both dictionaries have jsonPayloads,
+            Convert the json strings to dictionaries,
+            Merge and convert back to json strings
+            Set back to "jsonPayload" key
+        */
+        if let payload1 = dict1["jsonPayload"] as? String, let payload2 = dict2["jsonPayload"] as? String {
+            if let jsonDict1 = payload1.convertStringToDict(), let jsonDict2 = payload2.convertStringToDict() {
+                let jsonResult = jsonDict2.merging(jsonDict1) {(current, _) in current }
+                let jsonString = ENNavigationUtils.jsonToString(json: jsonResult)
+                result["jsonPayload"] = jsonString
+            }
+        }
+        return result
     }
 
     func deinitRNView() {

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBaseNavigationController.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENBaseNavigationController.swift
@@ -26,7 +26,7 @@ open class ENBaseNavigationController: UINavigationController, ENMiniAppNavDataP
         return false
     }
     open var finish: Payload?
-    open var backToMiniApp: BackToRoute = { _, _ in
+    open var backTo: BackToRoute = { _, _ in
         return false
     }
 
@@ -42,7 +42,7 @@ open class ENBaseNavigationController: UINavigationController, ENMiniAppNavDataP
         self.finish = { payload in
             self.finishFlow(payload)
         }
-        self.backToMiniApp = { componentName, backProperties in
+        self.backTo = { componentName, backProperties in
             return self.backToMiniApp(componentName, backProperties)
         }
     }

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationDelegate.swift
@@ -476,19 +476,3 @@ import UIKit
         return "{\"id\": \"" + buttonId + "\"}"
     }
 }
-
-extension String {
-    func convertStringToDict() -> [AnyHashable: Any]? {
-        do {
-            if let data = self.data(using: String.Encoding.utf8), let dict = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [AnyHashable: Any] {
-                return dict
-            } else {
-                return nil
-            }
-        } catch let error as NSError {
-            let logger = ElectrodeConsoleLogger.sharedInstance()
-            logger.log(.error, message: error.description)
-        }
-        return nil
-    }
-}

--- a/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationUtils.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Navigation/ENNavigationUtils.swift
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Walmart Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+class ENNavigationUtils {
+
+    static func jsonToString(json: [AnyHashable: Any]) -> String {
+        do {
+            let data1 =  try JSONSerialization.data(withJSONObject: json, options: JSONSerialization.WritingOptions.fragmentsAllowed) // first of all convert json to the data
+            let convertedString = String(data: data1, encoding: String.Encoding.utf8) // the data will be converted to the string
+            return convertedString ?? ""
+        } catch let error as NSError {
+            let logger = ElectrodeConsoleLogger.sharedInstance()
+            logger.log(.error, message: error.description)
+        }
+        return ""
+    }
+
+}
+
+extension String {
+
+    func convertStringToDict() -> [AnyHashable: Any]? {
+        do {
+            if let data = self.data(using: String.Encoding.utf8), let dict = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [AnyHashable: Any] {
+                return dict
+            } else {
+                return nil
+            }
+        } catch let error as NSError {
+            let logger = ElectrodeConsoleLogger.sharedInstance()
+            logger.log(.error, message: error.description)
+        }
+        return nil
+    }
+
+}


### PR DESCRIPTION
Changes:
- Namespace error on backToMiniApp property, conflicts with method of same name, renamed this property to backTo
- JSON payloads were not being merged properly, were being overwritten instead
- Moved common code to util class