### PR TITLE
RN library fix for xcode12.5 compilation

### DIFF
--- a/ios/ElectrodeApiImpl/Libraries/ReactNative/React/CxxBridge/RCTCxxBridge.mm
+++ b/ios/ElectrodeApiImpl/Libraries/ReactNative/React/CxxBridge/RCTCxxBridge.mm
@@ -743,7 +743,7 @@ struct RCTInstanceCallback : public InstanceCallback {
 #endif
 }
 
-- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules
+- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
                                withDispatchGroup:(dispatch_group_t)dispatchGroup
                                 lazilyDiscovered:(BOOL)lazilyDiscovered
 {


### PR DESCRIPTION
RN library should be a dependency and not be directly updated here, but for the time being, updating this directly so that code will compile on Xcode 12.5 (backward compataible)