### PR TITLE
fix a navigateInternal issue on iOS side

### DIFF
--- a/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
+++ b/ios/ElectrodeApiImpl/APIImpls/Core/ENCoreDelegate.swift
@@ -85,12 +85,24 @@ import UIKit
             Merge and convert back to json strings
             Set back to "jsonPayload" key
         */
-        if let payload1 = dict1["jsonPayload"] as? String, let payload2 = dict2["jsonPayload"] as? String {
-            if let jsonDict1 = payload1.convertStringToDict(), let jsonDict2 = payload2.convertStringToDict() {
+        let payload1 = dict1["jsonPayload"] as? String
+        let payload2 = dict2["jsonPayload"] as? String
+        if let payload1 = payload1, let payload2 = payload2 {
+            let jsonDict1 = payload1.convertStringToDict()
+            let jsonDict2 = payload2.convertStringToDict()
+            if let jsonDict1 = jsonDict1, let jsonDict2 = jsonDict2 {
                 let jsonResult = jsonDict2.merging(jsonDict1) {(current, _) in current }
                 let jsonString = ENNavigationUtils.jsonToString(json: jsonResult)
                 result["jsonPayload"] = jsonString
+            } else if let _ = jsonDict1 {
+                result["jsonPayload"] = payload1
+            } else {
+                result["jsonPayload"] = payload2
             }
+        } else if payload1 = payload1 {
+            result["jsonPayload"] = payload1
+        } else {
+            result["jsonPayload"] = payload2
         }
         return result
     }


### PR DESCRIPTION
when react native is calling navigateInternal(), if we have both globalproperties and properties passed in from react native side, and one of them is missing "jsonPayload", we removed this "jsonPayload" from properties. this PR fixed this issue.