### PR TITLE
Update view model providers to provider due to deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
-      - run: echo "y" | /usr/local/lib/android/sdk/tools/bin/sdkmanager "ndk;21.0.6113669"
+          node-version: '18'
+      - uses: android-actions/setup-android@v3
+      - run: sdkmanager "ndk;27.1.12297006"
       - run: npm i -g electrode-native
       - uses: actions/checkout@v3
         with:
@@ -31,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '12.4.0'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn --frozen-lockfile
       - run: npm publish --access public

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,17 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:8.7.2'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
 }

--- a/android/ern-navigation-support-lib/build.gradle
+++ b/android/ern-navigation-support-lib/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    namespace 'com.walmartlabs.ern.navigation.support.lib'
+    compileSdkVersion 35
+    buildToolsVersion "35.0.0"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdkVersion 24
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -21,15 +22,15 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 apply from: 'maven-publish.gradle'

--- a/android/ern-navigation-support-lib/maven-publish.gradle
+++ b/android/ern-navigation-support-lib/maven-publish.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
@@ -39,66 +39,63 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
-afterEvaluate { project ->
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+task androidSourcesJar(type: Jar) {
+    archiveClassifier = 'sources'
+    from android.sourceSets.main.java.srcDirs
+}
 
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.default
+                groupId = GROUP
+                artifactId = POM_ARTIFACT_ID
+                version = VERSION_NAME
 
-                repository(url: getReleaseRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-                snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                    authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-                }
-
-                pom.project {
-                    name POM_NAME
-                    packaging POM_PACKAGING
-                    description POM_DESCRIPTION
-                    url POM_URL
+                pom {
+                    name = POM_NAME
+                    packaging = POM_PACKAGING
+                    description = POM_DESCRIPTION
+                    url = POM_URL
 
                     scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
                     }
 
                     licenses {
                         license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
                         }
                     }
 
                     developers {
                         developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
+                            id = POM_DEVELOPER_ID
+                            name = POM_DEVELOPER_NAME
                         }
                     }
                 }
             }
         }
+        repositories {
+            maven {
+                def releasesRepoUrl = getReleaseRepositoryUrl()
+                def snapshotsRepoUrl = getSnapshotRepositoryUrl()
+                url = isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
+                credentials {
+                    username = getRepositoryUsername()
+                    password = getRepositoryPassword()
+                }
+            }
+        }
     }
-
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-        sign configurations.archives
-    }
-
-
-    task androidSourcesJar(type: Jar) {
-        archiveClassifier.set("sources")
-        from android.sourceSets.main.java.sourceFiles
-    }
-
-    artifacts {
-        archives androidSourcesJar
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("publish") }
+        sign publishing.publications.release
     }
 }

--- a/android/ern-navigation-support-lib/src/main/AndroidManifest.xml
+++ b/android/ern-navigation-support-lib/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.walmartlabs.ern.navigation.res.lib">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    namespace 'com.walmartlabs.ern.navigation'
+    compileSdkVersion 35
+    buildToolsVersion "35.0.0"
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 28
+        minSdkVersion 24
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -28,8 +29,8 @@ android {
         unitTests.returnDefaultValues = true
     }
     compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 

--- a/android/lib/src/androidTest/AndroidManifest.xml
+++ b/android/lib/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.walmartlabs.ern.navigation.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <activity

--- a/android/lib/src/main/AndroidManifest.xml
+++ b/android/lib/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="com.walmartlabs.ern.navigation">
+<manifest>
 </manifest>

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeNavigationFragmentDelegate.java
@@ -17,7 +17,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.ern.api.impl.core.ActivityDelegateConstants;
 import com.ern.api.impl.core.ElectrodeBaseFragmentDelegate;
@@ -160,12 +160,12 @@ public class ElectrodeNavigationFragmentDelegate<T extends ElectrodeBaseFragment
         // This is because calling add() or show() will not trigger a lifecycle method (onPause() or onStop()) on the previous fragment.
         // Not registering a view model in this case will prevent multiple request handlers getting registered at the same time.
         if (args != null && args.getBoolean(ActivityDelegateConstants.KEY_REGISTER_NAV_VIEW_MODEL)) {
-            mNavViewModel = ViewModelProviders.of(mFragment).get(ReactNavigationViewModel.class);
+            mNavViewModel = new ViewModelProvider(mFragment).get(ReactNavigationViewModel.class);
             mNavViewModel.getRouteLiveData().observe(mFragment.getViewLifecycleOwner(), routeObserver);
             mNavViewModel.registerNavRequestHandler();
         }
 
-        mActionBarStatusViewModel = ViewModelProviders.of(mFragment.requireActivity()).get(ActionBarStatusViewModel.class);
+        mActionBarStatusViewModel = new ViewModelProvider(mFragment.requireActivity()).get(ActionBarStatusViewModel.class);
     }
 
     @CallSuper

--- a/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeReactFragmentNavDelegate.java
+++ b/android/lib/src/main/java/com/ern/api/impl/navigation/ElectrodeReactFragmentNavDelegate.java
@@ -32,7 +32,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.ern.api.impl.core.ElectrodeReactFragmentActivityDelegate.StartMiniAppConfig;
 import com.ern.api.impl.core.ElectrodeReactFragmentDelegate;
@@ -128,7 +128,7 @@ public class ElectrodeReactFragmentNavDelegate extends ElectrodeReactFragmentDel
     @CallSuper
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-        mNavViewModel = ViewModelProviders.of(mFragment).get(ReactNavigationViewModel.class);
+        mNavViewModel = new ViewModelProvider(mFragment).get(ReactNavigationViewModel.class);
         mNavViewModel.getRouteLiveData().observe(mFragment.getViewLifecycleOwner(), routeObserver);
 
     }

--- a/android/moviesreloaded/build.gradle
+++ b/android/moviesreloaded/build.gradle
@@ -2,12 +2,13 @@ apply plugin: 'com.android.application'
 apply from: 'ern.gradle'
 
 android {
-    compileSdkVersion 28
+    namespace 'com.walmartlabs.moviesreloaded'
+    compileSdkVersion 35
 
     defaultConfig {
         applicationId "com.walmartlabs.moviesreloaded"
-        minSdkVersion 23
-        targetSdkVersion 28
+        minSdkVersion 24
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -22,11 +23,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
-    buildToolsVersion = '28.0.3'
-    ndkVersion "21.0.6113669"
+    buildToolsVersion = '35.0.0'
+    ndkVersion "27.1.12297006"
 }
 
 dependencies {

--- a/android/moviesreloaded/src/main/AndroidManifest.xml
+++ b/android/moviesreloaded/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.walmartlabs.moviesreloaded">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
**androidx.lifecycle.ViewModelProviders** has been deprecated

https://developer.android.com/reference/androidx/lifecycle/ViewModelProviders

Due to new android gradle, we need to use ViewModelProvider from **androidx.lifecycle.ViewModelProvider** instead

-------

- Android Gradle Plugin: Updated from 3.5.3 → 8.1.4 (compatible with Gradle 8.11.1)
- Repository: Replaced deprecated jcenter() with mavenCentral()
- Java Version: Updated all modules from Java 8 → Java 17
- Gradle JVM Args: Increased memory allocation and added performance optimizations
- Gradle 8+ Compatible: Uses the modern maven-publish plugin

Closes #198 